### PR TITLE
Update Python versions tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.7"
     - "3.8"
     - "3.9-dev"
+    - "pypy3"
 
 install:
     - pip install --upgrade setuptools coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: python
 dist: xenial
 
 python:
-    - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
-    - "pypy2.7-6.0"
-    - "pypy3.5-6.0"
+    - "3.8"
+    - "3.9-dev"
 
 install:
     - pip install --upgrade setuptools coveralls


### PR DESCRIPTION
This PR adds testing for Python 3.8 and 3.9-dev, as well as the latest Travis version of PyPy3.

It drops testing for CPython 2.7 and 3.4, which are EOL.